### PR TITLE
Add Scout admin policy files and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
-# Project
+# Microsoft Scout Resources
 
-> This repo has been populated by an initial template to help get you started. Please
-> make sure to update the content to build a great experience for community-building.
-
-As the maintainer of this project, please make a few updates:
-
-- Improving this README.MD file to provide a great experience
-- Updating SUPPORT.MD with content about this project's support experience
-- Understanding the security reporting process in SECURITY.MD
-- Remove this section from the README
-
-## Contributing
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit [Contributor License Agreements](https://cla.opensource.microsoft.com).
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-## Trademarks
-
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+Resources for Microsoft Scout admins and users.

--- a/admins/microsoft-scout.adml
+++ b/admins/microsoft-scout.adml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Microsoft Scout Group Policy Language File (ADML) - English (US)
+  Deploy to: %systemroot%\PolicyDefinitions\en-US\microsoft-scout.adml
+-->
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                           xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                           revision="1.0"
+                           schemaVersion="1.0"
+                           xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+
+  <displayName>Microsoft Scout AI Desktop Assistant</displayName>
+  <description>Group Policy settings for the Microsoft Scout AI desktop assistant.</description>
+
+  <resources>
+    <stringTable>
+      <!-- Categories -->
+      <string id="Cat_MicrosoftScout">Microsoft Scout</string>
+      <string id="Cat_Capabilities">Capabilities</string>
+      <string id="Cat_Models">AI Models</string>
+      <string id="Cat_Security">Security</string>
+
+      <!-- Supported On -->
+      <string id="SUPPORTED_Windows10">Windows 10 or later</string>
+
+      <!-- PolicyVersion -->
+      <string id="PolicyVersion">Policy version</string>
+      <string id="PolicyVersion_Help">Specifies the policy schema version (integer).
+
+Used for diagnostics and future schema migrations. Does not affect runtime behavior directly.</string>
+
+      <!-- DisabledServers -->
+      <string id="DisabledServers">Disabled MCP servers</string>
+      <string id="DisabledServers_Help">Comma-separated list of MCP server config keys to block.
+
+Example: filesystem,playwright
+
+Valid keys: filesystem, playwright, plus any custom MCP servers configured by the user. When a server appears in this list, all tools from that server are denied.</string>
+
+      <!-- DisabledPermissions -->
+      <string id="DisabledPermissions">Disabled permission kinds</string>
+      <string id="DisabledPermissions_Help">Comma-separated list of permission kinds to unconditionally deny.
+
+Valid values: shell, write, mcp, url, custom-tool
+
+Example: shell,write
+
+When a kind is listed, all tool calls requiring that permission are blocked without prompting the user.</string>
+
+      <!-- ForcePrompt -->
+      <string id="ForcePrompt">Force human approval for all non-read actions</string>
+      <string id="ForcePrompt_Help">When enabled, every tool call that is not a read-only operation requires explicit user approval, regardless of auto-approve settings.
+
+This overrides global and per-server auto-approve preferences.</string>
+
+      <!-- DisabledModels -->
+      <string id="DisabledModels">Disabled AI models</string>
+      <string id="DisabledModels_Help">Comma-separated list of model IDs to block.
+
+Example: gpt-4o,claude-3-5-sonnet
+
+Blocked models are hidden from the model picker and cannot be selected for new sessions. If the user's default model is blocked, the app falls back to the first allowed model.</string>
+
+      <!-- DisabledProviders -->
+      <string id="DisabledProviders">Disabled AI model providers</string>
+      <string id="DisabledProviders_Help">Comma-separated list of inference provider names to block.
+
+Example: anthropic,openai
+
+All models from blocked providers are hidden from the model picker and cannot be used.</string>
+
+      <!-- DisableHeartbeat -->
+      <string id="DisableHeartbeat">Disable Heartbeat</string>
+      <string id="DisableHeartbeat_Help">When enabled, the Heartbeat feature (periodic automated check-in) is completely disabled. The Heartbeat toggle in settings is hidden and the feature cannot be re-enabled by the user.</string>
+
+      <!-- DisableWorkflows -->
+      <string id="DisableWorkflows">Disable Automations</string>
+      <string id="DisableWorkflows_Help">When enabled, automation creation and scheduled execution are disabled. Existing automations will not run, and the Automations panel is hidden from the user.</string>
+
+      <!-- RestrictToWorkspace -->
+      <string id="RestrictToWorkspace">Restrict filesystem access to workspace</string>
+      <string id="RestrictToWorkspace_Help">When enabled, file system and shell access is restricted to the current workspace directory only. The MCP filesystem server will not have access to skill directories, automation resources, or other paths outside the workspace.
+
+Use this to limit the assistant's ability to read or modify files outside the project directory.</string>
+
+      <!-- BrowserEgressBlockedOrigins -->
+      <string id="BrowserEgressBlockedOrigins">Blocked browser egress origins</string>
+      <string id="BrowserEgressBlockedOrigins_Help">Comma-separated list of origins to block outbound from the Playwright browser context.
+
+Example: https://evil.com,https://tracker.example.com
+
+Only well-formed http/https origins are accepted (scheme + host + optional port). Entries with paths, queries, or fragments are silently ignored. When a navigation or request targets a blocked origin, it is denied by the browser context before the request leaves the device.</string>
+
+      <!-- AllowScoutFrontierAccess -->
+      <string id="AllowScoutFrontierAccess">Allow Microsoft Scout Frontier access</string>
+      <string id="AllowScoutFrontierAccess_Help">Controls access to Microsoft Scout in Frontier (pre-release) builds for this tenant.
+
+When enabled, frontier-mode users in this tenant can sign in and use Microsoft Scout normally.
+
+When disabled or not configured, frontier-mode users see a waitlist screen and cannot proceed past sign-in. This setting has no effect on regular release or beta builds - those remain available to all users.
+
+Use this to perform a controlled rollout of new Frontier capabilities by opting tenants in explicitly.</string>
+
+    </stringTable>
+
+    <presentationTable>
+
+      <presentation id="PolicyVersion">
+        <decimalTextBox refId="PolicyVersion_Value" defaultValue="1">Policy version:</decimalTextBox>
+      </presentation>
+
+      <presentation id="DisabledServers">
+        <textBox refId="DisabledServers_Value">
+          <label>Server config keys (comma-separated):</label>
+          <defaultValue></defaultValue>
+        </textBox>
+      </presentation>
+
+      <presentation id="DisabledPermissions">
+        <textBox refId="DisabledPermissions_Value">
+          <label>Permission kinds (comma-separated):</label>
+          <defaultValue></defaultValue>
+        </textBox>
+      </presentation>
+
+      <presentation id="DisabledModels">
+        <textBox refId="DisabledModels_Value">
+          <label>Model IDs (comma-separated):</label>
+          <defaultValue></defaultValue>
+        </textBox>
+      </presentation>
+
+      <presentation id="DisabledProviders">
+        <textBox refId="DisabledProviders_Value">
+          <label>Provider names (comma-separated):</label>
+          <defaultValue></defaultValue>
+        </textBox>
+      </presentation>
+
+      <presentation id="BrowserEgressBlockedOrigins">
+        <textBox refId="BrowserEgressBlockedOrigins_Value">
+          <label>Blocked origins (comma-separated):</label>
+          <defaultValue></defaultValue>
+        </textBox>
+      </presentation>
+
+    </presentationTable>
+
+  </resources>
+
+</policyDefinitionResources>

--- a/admins/microsoft-scout.admx
+++ b/admins/microsoft-scout.admx
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Microsoft Scout Group Policy Administrative Template (ADMX)
+  Deploy to: %systemroot%\PolicyDefinitions\microsoft-scout.admx
+  Language file: %systemroot%\PolicyDefinitions\en-US\microsoft-scout.adml
+
+  Registry key: HKLM\SOFTWARE\Policies\Scout
+  All settings are machine-level (Class="Machine").
+-->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                   revision="1.0"
+                   schemaVersion="1.0"
+                   xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+
+  <policyNamespaces>
+    <target prefix="microsoftscout" namespace="MicrosoftScout.Policies.Scout" />
+  </policyNamespaces>
+
+  <resources minRequiredRevision="1.0" />
+
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_Windows10" displayName="$(string.SUPPORTED_Windows10)" />
+    </definitions>
+  </supportedOn>
+
+  <categories>
+    <category name="MicrosoftScout" displayName="$(string.Cat_MicrosoftScout)" />
+    <category name="Capabilities" displayName="$(string.Cat_Capabilities)">
+      <parentCategory ref="MicrosoftScout" />
+    </category>
+    <category name="Models" displayName="$(string.Cat_Models)">
+      <parentCategory ref="MicrosoftScout" />
+    </category>
+    <category name="Security" displayName="$(string.Cat_Security)">
+      <parentCategory ref="MicrosoftScout" />
+    </category>
+  </categories>
+
+  <policies>
+
+    <!-- PolicyVersion (DWORD) -->
+    <policy name="PolicyVersion"
+            class="Machine"
+            displayName="$(string.PolicyVersion)"
+            explainText="$(string.PolicyVersion_Help)"
+            presentation="$(presentation.PolicyVersion)"
+            key="SOFTWARE\Policies\Scout">
+      <parentCategory ref="MicrosoftScout" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <elements>
+        <decimal id="PolicyVersion_Value" valueName="PolicyVersion" minValue="1" maxValue="9999" />
+      </elements>
+    </policy>
+
+    <!-- DisabledServers (REG_SZ, comma-separated) -->
+    <policy name="DisabledServers"
+            class="Machine"
+            displayName="$(string.DisabledServers)"
+            explainText="$(string.DisabledServers_Help)"
+            presentation="$(presentation.DisabledServers)"
+            key="SOFTWARE\Policies\Scout">
+      <parentCategory ref="Capabilities" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <elements>
+        <text id="DisabledServers_Value" valueName="DisabledServers" maxLength="1024" />
+      </elements>
+    </policy>
+
+    <!-- DisabledPermissions (REG_SZ, comma-separated) -->
+    <policy name="DisabledPermissions"
+            class="Machine"
+            displayName="$(string.DisabledPermissions)"
+            explainText="$(string.DisabledPermissions_Help)"
+            presentation="$(presentation.DisabledPermissions)"
+            key="SOFTWARE\Policies\Scout">
+      <parentCategory ref="Security" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <elements>
+        <text id="DisabledPermissions_Value" valueName="DisabledPermissions" maxLength="1024" />
+      </elements>
+    </policy>
+
+    <!-- ForcePrompt (DWORD 0/1) -->
+    <policy name="ForcePrompt"
+            class="Machine"
+            displayName="$(string.ForcePrompt)"
+            explainText="$(string.ForcePrompt_Help)"
+            key="SOFTWARE\Policies\Scout"
+            valueName="ForcePrompt">
+      <parentCategory ref="Security" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <enabledValue><decimal value="1" /></enabledValue>
+      <disabledValue><decimal value="0" /></disabledValue>
+    </policy>
+
+    <!-- DisabledModels (REG_SZ, comma-separated) -->
+    <policy name="DisabledModels"
+            class="Machine"
+            displayName="$(string.DisabledModels)"
+            explainText="$(string.DisabledModels_Help)"
+            presentation="$(presentation.DisabledModels)"
+            key="SOFTWARE\Policies\Scout">
+      <parentCategory ref="Models" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <elements>
+        <text id="DisabledModels_Value" valueName="DisabledModels" maxLength="1024" />
+      </elements>
+    </policy>
+
+    <!-- DisabledProviders (REG_SZ, comma-separated) -->
+    <policy name="DisabledProviders"
+            class="Machine"
+            displayName="$(string.DisabledProviders)"
+            explainText="$(string.DisabledProviders_Help)"
+            presentation="$(presentation.DisabledProviders)"
+            key="SOFTWARE\Policies\Scout">
+      <parentCategory ref="Models" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <elements>
+        <text id="DisabledProviders_Value" valueName="DisabledProviders" maxLength="1024" />
+      </elements>
+    </policy>
+
+    <!-- DisableHeartbeat (DWORD 0/1) -->
+    <policy name="DisableHeartbeat"
+            class="Machine"
+            displayName="$(string.DisableHeartbeat)"
+            explainText="$(string.DisableHeartbeat_Help)"
+            key="SOFTWARE\Policies\Scout"
+            valueName="DisableHeartbeat">
+      <parentCategory ref="Capabilities" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <enabledValue><decimal value="1" /></enabledValue>
+      <disabledValue><decimal value="0" /></disabledValue>
+    </policy>
+
+    <!-- DisableWorkflows (DWORD 0/1) -->
+    <policy name="DisableWorkflows"
+            class="Machine"
+            displayName="$(string.DisableWorkflows)"
+            explainText="$(string.DisableWorkflows_Help)"
+            key="SOFTWARE\Policies\Scout"
+            valueName="DisableWorkflows">
+      <parentCategory ref="Capabilities" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <enabledValue><decimal value="1" /></enabledValue>
+      <disabledValue><decimal value="0" /></disabledValue>
+    </policy>
+
+    <!-- RestrictToWorkspace (DWORD 0/1) -->
+    <policy name="RestrictToWorkspace"
+            class="Machine"
+            displayName="$(string.RestrictToWorkspace)"
+            explainText="$(string.RestrictToWorkspace_Help)"
+            key="SOFTWARE\Policies\Scout"
+            valueName="RestrictToWorkspace">
+      <parentCategory ref="Security" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <enabledValue><decimal value="1" /></enabledValue>
+      <disabledValue><decimal value="0" /></disabledValue>
+    </policy>
+
+    <!-- BrowserEgressBlockedOrigins (REG_SZ, comma-separated)
+         Element-based policy: valueName lives on the child <text> element, NOT on
+         the <policy> tag. Having it on both triggers Intune CSP error 131329. -->
+    <policy name="BrowserEgressBlockedOrigins"
+            class="Machine"
+            displayName="$(string.BrowserEgressBlockedOrigins)"
+            explainText="$(string.BrowserEgressBlockedOrigins_Help)"
+            presentation="$(presentation.BrowserEgressBlockedOrigins)"
+            key="SOFTWARE\Policies\Scout">
+      <parentCategory ref="Security" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <elements>
+        <text id="BrowserEgressBlockedOrigins_Value" valueName="BrowserEgressBlockedOrigins" maxLength="2048" />
+      </elements>
+    </policy>
+
+    <!-- AllowScoutFrontierAccess (DWORD 0/1)
+         Toggle policy: valueName correctly lives on the <policy> tag (this is the
+         non-buggy shape - only element-based policies must omit it here). -->
+    <policy name="AllowScoutFrontierAccess"
+            class="Machine"
+            displayName="$(string.AllowScoutFrontierAccess)"
+            explainText="$(string.AllowScoutFrontierAccess_Help)"
+            key="SOFTWARE\Policies\Scout"
+            valueName="AllowScoutFrontierAccess">
+      <parentCategory ref="Capabilities" />
+      <supportedOn ref="SUPPORTED_Windows10" />
+      <enabledValue><decimal value="1" /></enabledValue>
+      <disabledValue><decimal value="0" /></disabledValue>
+    </policy>
+
+  </policies>
+
+</policyDefinitions>

--- a/admins/microsoft-scout.mobileconfig
+++ b/admins/microsoft-scout.mobileconfig
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Microsoft Scout - macOS Tenant Policy Profile
+
+  Upload this file to Intune (Devices > macOS > Configuration > Custom)
+  or Jamf (Configuration Profiles > Custom Settings) to enforce tenant
+  admin controls on managed Macs.
+
+  Deployment channel: Device channel
+  Domain: com.microsoft.clawpilot
+
+  To customize: enable/disable individual keys below.  Remove any <key>
+  you don't need - absent keys are not enforced (same as "Not configured"
+  in Windows GPO).
+
+  Available keys and types:
+    PolicyVersion          integer     Schema version (set to 1)
+    ForcePrompt            boolean     Require human approval for tool calls
+    DisableHeartbeat       boolean     Disable heartbeat telemetry
+    DisableWorkflows       boolean     Disable automations
+    RestrictToWorkspace    boolean     Restrict filesystem access to workspace
+    AllowScoutFrontierAccess boolean   Allow access to frontier models
+    DisabledServers        array<string>  MCP servers to block (e.g. "WorkIQ", "filesystem")
+    DisabledModels         array<string>  Models to hide (e.g. "o3-mini", "gpt-5")
+    DisabledPermissions    array<string>  Permission kinds to revoke (e.g. "shell")
+    DisabledProviders      array<string>  Providers to block
+    BrowserEgressBlockedOrigins  array<string>  Origins to block for browser egress (e.g. "https://evil.com")
+-->
+<plist version="1.0">
+<dict>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadType</key>
+            <string>com.microsoft.clawpilot</string>
+            <key>PayloadIdentifier</key>
+            <string>com.microsoft.clawpilot.policy</string>
+            <key>PayloadUUID</key>
+            <string>A1B2C3D4-E5F6-7890-ABCD-EF1234567890</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>PayloadDisplayName</key>
+            <string>Microsoft Scout Tenant Policy</string>
+
+            <!-- == Policy settings == -->
+
+            <key>PolicyVersion</key>
+            <integer>1</integer>
+
+            <key>AllowScoutFrontierAccess</key>
+            <true/>
+
+            <!--
+            <key>ForcePrompt</key>
+            <true/>
+
+            <key>DisableHeartbeat</key>
+            <false/>
+
+            <key>DisableWorkflows</key>
+            <false/>
+
+            <key>RestrictToWorkspace</key>
+            <false/>
+
+            <key>DisabledServers</key>
+            <array>
+                <string>WorkIQ</string>
+            </array>
+
+            <key>DisabledModels</key>
+            <array>
+                <string>o3-mini</string>
+            </array>
+
+            <key>DisabledPermissions</key>
+            <array>
+                <string>shell</string>
+            </array>
+
+            <key>DisabledProviders</key>
+            <array/>
+
+            <key>BrowserEgressBlockedOrigins</key>
+            <array>
+                <string>https://evil.com</string>
+            </array>
+            -->
+        </dict>
+    </array>
+    <key>PayloadIdentifier</key>
+    <string>com.microsoft.clawpilot.tenant-policy</string>
+    <key>PayloadUUID</key>
+    <string>F1E2D3C4-B5A6-7890-1234-567890ABCDEF</string>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+    <key>PayloadDisplayName</key>
+    <string>Microsoft Scout Tenant Policy</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add Intune policy templates (ADMX, ADML, mobileconfig) under `admins/` for Microsoft Scout Frontier access
- Replace boilerplate README with project description

## Test plan
- [ ] Verify ADMX/ADML files import successfully in Intune
- [ ] Verify mobileconfig deploys correctly to macOS devices