### PR TITLE
Document lower-friction Scout policy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Microsoft Scout Resources
 
 Resources for Microsoft Scout admins and users.
+
+## Reducing approval prompts
+
+If Scout is prompting too often, start with the macOS tenant policy profile in
+`admins/microsoft-scout.mobileconfig` and set `ForcePrompt` to `false`. Then
+use `DisabledPermissions` and `DisabledServers` only for the capabilities you
+actually want to keep gated.

--- a/admins/microsoft-scout.mobileconfig
+++ b/admins/microsoft-scout.mobileconfig
@@ -52,9 +52,14 @@
             <true/>
 
             <!--
+              Set ForcePrompt to false to avoid prompting on every tool call.
+              Keep DisabledPermissions/DisabledServers narrow so only the risky
+              capabilities stay gated.
+            -->
             <key>ForcePrompt</key>
-            <true/>
+            <false/>
 
+            <!--
             <key>DisableHeartbeat</key>
             <false/>
 


### PR DESCRIPTION
This updates the macOS tenant policy sample to show the low-friction setup more clearly:\n- set ForcePrompt to false\n- keep only the risky capabilities gated via DisabledPermissions / DisabledServers\n- add a short README note so admins can reduce approval prompts without disabling safety controls entirely